### PR TITLE
SyncBot CLI Fixes

### DIFF
--- a/SyncBotCLI/Program.cs
+++ b/SyncBotCLI/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -32,9 +32,16 @@ namespace SyncBotCLI
 			worker.Error += OnError;
 
 			worker.InitializePerforce(user, password, workspace, server);
-			Task task = worker.Sync(path);
 
-			task.Wait();
+            try
+            {
+                Task task = worker.Sync(path);
+                task.Wait();
+            }
+            catch (AggregateException ae)
+            {
+                Console.WriteLine(ae.InnerException.Message);
+            }
 
 			Console.WriteLine("Finished.");
 		}


### PR DESCRIPTION
1) Initialize filesToSync to prevent an exception when there are 0 files to sync (bad path or files are up to date).
2) Add try/catch to the p4.Run command in GatherFiles to log errors created by the p4.Run command.
3) Remove check for P4PASSWD being set - Perforce will throw an exception before this.
4) Add global exception handling to Task to report exceptions rather than throw unhandled exceptions.
